### PR TITLE
[FEATURE] Add 9 LTS and drop 6 LTS compatibility

### DIFF
--- a/Classes/Controller/OnepageController.php
+++ b/Classes/Controller/OnepageController.php
@@ -138,10 +138,11 @@ class OnepageController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControll
     private function getPages($pageUid)
     {
         $pages = explode(',', $this->settings['pages']);
+        $sorting = $this->settings['pagesOrdering'] ? $this->settings['pagesOrdering'] : 'uid';
         if ((boolean)$this->settings['allSubPages']) {
             /** @var Pages[] $pagesArray */
             $pages = array();
-            $pagesArray = $this->pagesRepository->findByPid($pageUid);
+            $pagesArray = $this->pagesRepository->findByPid($pageUid, $sorting);
             foreach ($pagesArray as $page) {
                 $pages[] = $page->getUid();
             }

--- a/Classes/Domain/Repository/PagesRepository.php
+++ b/Classes/Domain/Repository/PagesRepository.php
@@ -34,11 +34,14 @@ namespace BERGWERK\BwrkOnepage\Domain\Repository;
  */
 class PagesRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 {
-    public function findByPid($pageUid)
+    public function findByPid($pageUid, $sorting)
     {
         $query = $this->createQuery();
         $query->getQuerySettings()->setRespectStoragePage(false);
-
+        $query->setOrderings([
+            // Order by Flexform selection
+            $sorting => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_ASCENDING
+        ]);
         $query->matching(
             $query->logicalAnd(
                 $query->equals('pid', $pageUid),

--- a/Configuration/FlexForms/Show.xml
+++ b/Configuration/FlexForms/Show.xml
@@ -89,6 +89,35 @@
                             </config>
                         </TCEforms>
                     </settings.pages>
+                    <settings.pagesOrdering>
+                        <TCEforms>
+                            <label>
+                                LLL:EXT:bwrk_onepage/Resources/Private/Language/locallang.xlf:bwrk_onepage.settings.pagesOrdering
+                            </label>
+                            <displayCond>FIELD:settings.allSubPages:=:1</displayCond>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectSingle</renderType>
+                                <items type="array">
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">
+                                            LLL:EXT:bwrk_onepage/Resources/Private/Language/locallang.xlf:bwrk_onepage.settings.pagesOrdering.uid
+                                        </numIndex>
+                                        <numIndex index="1">uid</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">
+                                            LLL:EXT:bwrk_onepage/Resources/Private/Language/locallang.xlf:bwrk_onepage.settings.pagesOrdering.sorting
+                                        </numIndex>
+                                        <numIndex index="1">sorting</numIndex>
+                                    </numIndex>
+                                </items>
+                                <minitems>0</minitems>
+                                <maxitems>1</maxitems>
+                                <size>1</size>
+                            </config>
+                        </TCEforms>
+                    </settings.pagesOrdering>
                 </el>
             </ROOT>
         </general>

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,9 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+// Typoscript
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    'bwrk_onepage',
+    'Configuration/TypoScript',
+    'BERGWERK Onepage [Viewer]'
+);

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,14 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
+    'BERGWERK.bwrk_onepage',
+    'Pi1',
+    'BERGWERK Onepage Viewer'
+);
+
+// Flexform einbinden
+$pluginSignature = 'bwrkonepage_pi1';
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist'][$pluginSignature] = 'layout,select_key,pages';
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($pluginSignature, 'FILE:EXT:bwrk_onepage/Configuration/FlexForms/Show.xml');

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,15 +1,18 @@
 plugin.tx_bwrkonepage {
     view {
         templateRootPaths {
-            0 = {$plugin.tx_bwrkonepage.view.templateRootPath}
+            0 = EXT:bwrk_onepage/Resources/Private/Templates/
+            1 = {$plugin.tx_bwrkonepage.view.templateRootPath}
         }
 
         layoutRootPaths {
-            0 = {$plugin.tx_bwrkonepage.view.layoutRootPath}
+            0 = EXT:bwrk_onepage/Resources/Private/Layouts/
+            1 = {$plugin.tx_bwrkonepage.view.layoutRootPath}
         }
 
         partialRootPaths {
-            0 = {$plugin.tx_bwrkonepage.view.partialRootPath}
+            0 = EXT:bwrk_onepage/Resources/Private/Partials/
+            1 = {$plugin.tx_bwrkonepage.view.partialRootPath}
         }
     }
 

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -12,6 +12,15 @@
 			<trans-unit id="bwrk_onepage.settings.pages">
 				<target>Welche Seiten sollen angezeigt werden?</target>
 			</trans-unit>
+			<trans-unit id="bwrk_onepage.settings.pagesOrdering">
+				<target>Nach welchem Feld soll sortiert werden?</target>
+			</trans-unit>
+			<trans-unit id="bwrk_onepage.settings.pagesOrdering.sorting">
+				<target>sorting (selbe Reihenfolge wie im Seitenbaum)</target>
+			</trans-unit>
+			<trans-unit id="bwrk_onepage.settings.pagesOrdering.uid">
+				<target>uid (chronologisch)</target>
+			</trans-unit>
 			<trans-unit id="bwrk_onepage.settings.menu">
 				<target>Menü anzeigen?</target>
 			</trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -15,6 +15,15 @@
 			<trans-unit id="bwrk_onepage.settings.pages">
 				<source>Which Pages should be shown?</source>
 			</trans-unit>
+			<trans-unit id="bwrk_onepage.settings.pagesOrdering">
+				<source>Sorting should be done with which field?</source>
+			</trans-unit>
+			<trans-unit id="bwrk_onepage.settings.pagesOrdering.sorting">
+				<source>sorting (same as page tree)</source>
+			</trans-unit>
+			<trans-unit id="bwrk_onepage.settings.pagesOrdering.uid">
+				<source>uid (chronological)</source>
+			</trans-unit>
 			<trans-unit id="bwrk_onepage.settings.menu">
 				<source>Show Menu</source>
 			</trans-unit>

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
       "homepage": "https://www.bergwerk.ag"
     }
   ],
-  "version": "3.1.3",
+  "version": "3.2.0",
   "license": "GPL-2.0+",
   "description": "TYPO3 Onepage-Extension which allows you to use subpages as onepage layout.",
   "require": {
-    "typo3/cms-core": "^6.2.0 || ^7.6 || ^8.0"
+    "typo3/cms-core": "^7.6 || ^8.0 || ^9.5"
   },
   "replace": {
     "bwrk_onepage": "self.version",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -35,10 +35,10 @@ $EM_CONF[$_EXTKEY] = array(
     'author_email' => 'technik@bergwerk.ag',
     'author_company' => 'BERGWERK Werbeagentur GmbH',
     'state' => 'stable',
-    'version' => '3.1.3',
+    'version' => '3.2.0',
     'constraints' => array(
         'depends' => array(
-            'typo3' => '6.2.0-8.7.99',
+            'typo3' => '7.6.0-9.5.99',
         ),
         'conflicts' => array(),
         'suggests' => array()

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,24 +1,2 @@
 <?php
-
-if (!defined('TYPO3_MODE'))
-{
-    die('Access denied.');
-}
-
-\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-    'BERGWERK.'.$_EXTKEY,
-    'Pi1',
-    'BERGWERK Onepage Viewer'
-);
-
-// Typoscript
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'BERGWERK Onepage [Viewer]');
-
-
-// Flexform einbinden
-$extensionName = strtolower(\TYPO3\CMS\Core\Utility\GeneralUtility::underscoredToUpperCamelCase($_EXTKEY));
-$pluginName = strtolower('Pi1');
-$pluginSignature = $extensionName . '_' . $pluginName;
-$TCA['tt_content']['types']['list']['subtypes_excludelist'][$pluginSignature] = 'layout,select_key,pages';
-$TCA['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($pluginSignature, 'FILE:EXT:' . $_EXTKEY . '/Configuration/FlexForms/Show.xml');
+defined('TYPO3_MODE') or die();


### PR DESCRIPTION
Deprecated methods from Pagerenderer Class getHash() and storeHash() got removed in 9.0 - as stated by the Deprecation notice, the code can simply be copied into the third-party extensions' code.