### PR TITLE
[!!!][FEATURE] Breaking: Allow Sorting of menu Items

### DIFF
--- a/Classes/Controller/OnepageController.php
+++ b/Classes/Controller/OnepageController.php
@@ -138,10 +138,11 @@ class OnepageController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControll
     private function getPages($pageUid)
     {
         $pages = explode(',', $this->settings['pages']);
+        $sorting = $this->settings['pagesOrdering'] ? $this->settings['pagesOrdering'] : 'uid';
         if ((boolean)$this->settings['allSubPages']) {
             /** @var Pages[] $pagesArray */
             $pages = array();
-            $pagesArray = $this->pagesRepository->findByPid($pageUid);
+            $pagesArray = $this->pagesRepository->findByPid($pageUid, $sorting);
             foreach ($pagesArray as $page) {
                 $pages[] = $page->getUid();
             }

--- a/Classes/Domain/Repository/PagesRepository.php
+++ b/Classes/Domain/Repository/PagesRepository.php
@@ -34,11 +34,14 @@ namespace BERGWERK\BwrkOnepage\Domain\Repository;
  */
 class PagesRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 {
-    public function findByPid($pageUid)
+    public function findByPid($pageUid, $sorting)
     {
         $query = $this->createQuery();
         $query->getQuerySettings()->setRespectStoragePage(false);
-
+        $query->setOrderings([
+            // Order by Flexform selection
+            $sorting => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_ASCENDING
+        ]);
         $query->matching(
             $query->logicalAnd(
                 $query->equals('pid', $pageUid),

--- a/Configuration/FlexForms/Show.xml
+++ b/Configuration/FlexForms/Show.xml
@@ -89,6 +89,35 @@
                             </config>
                         </TCEforms>
                     </settings.pages>
+                    <settings.pagesOrdering>
+                        <TCEforms>
+                            <label>
+                                LLL:EXT:bwrk_onepage/Resources/Private/Language/locallang.xlf:bwrk_onepage.settings.pagesOrdering
+                            </label>
+                            <displayCond>FIELD:settings.allSubPages:=:1</displayCond>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectSingle</renderType>
+                                <items type="array">
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">
+                                            LLL:EXT:bwrk_onepage/Resources/Private/Language/locallang.xlf:bwrk_onepage.settings.pagesOrdering.uid
+                                        </numIndex>
+                                        <numIndex index="1">uid</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">
+                                            LLL:EXT:bwrk_onepage/Resources/Private/Language/locallang.xlf:bwrk_onepage.settings.pagesOrdering.sorting
+                                        </numIndex>
+                                        <numIndex index="1">sorting</numIndex>
+                                    </numIndex>
+                                </items>
+                                <minitems>0</minitems>
+                                <maxitems>1</maxitems>
+                                <size>1</size>
+                            </config>
+                        </TCEforms>
+                    </settings.pagesOrdering>
                 </el>
             </ROOT>
         </general>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -12,6 +12,15 @@
 			<trans-unit id="bwrk_onepage.settings.pages">
 				<target>Welche Seiten sollen angezeigt werden?</target>
 			</trans-unit>
+			<trans-unit id="bwrk_onepage.settings.pagesOrdering">
+				<target>Nach welchem Feld soll sortiert werden?</target>
+			</trans-unit>
+			<trans-unit id="bwrk_onepage.settings.pagesOrdering.sorting">
+				<target>sorting (selbe Reihenfolge wie im Seitenbaum)</target>
+			</trans-unit>
+			<trans-unit id="bwrk_onepage.settings.pagesOrdering.uid">
+				<target>uid (chronologisch)</target>
+			</trans-unit>
 			<trans-unit id="bwrk_onepage.settings.menu">
 				<target>Menü anzeigen?</target>
 			</trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -15,6 +15,15 @@
 			<trans-unit id="bwrk_onepage.settings.pages">
 				<source>Which Pages should be shown?</source>
 			</trans-unit>
+			<trans-unit id="bwrk_onepage.settings.pagesOrdering">
+				<source>Sorting should be done with which field?</source>
+			</trans-unit>
+			<trans-unit id="bwrk_onepage.settings.pagesOrdering.sorting">
+				<source>sorting (same as page tree)</source>
+			</trans-unit>
+			<trans-unit id="bwrk_onepage.settings.pagesOrdering.uid">
+				<source>uid (chronological)</source>
+			</trans-unit>
 			<trans-unit id="bwrk_onepage.settings.menu">
 				<source>Show Menu</source>
 			</trans-unit>


### PR DESCRIPTION
This feature allows to sort the menu items if you selected "show all
sub pages". Default sorting is "uid", which equals to the old
behavior "not sorting". This may break your existing menu.