### PR TITLE
compatibility with FLUX 9.7.2 (breaking change: virtual colPos)

### DIFF
--- a/Classes/Domain/Repository/ContentRepository.php
+++ b/Classes/Domain/Repository/ContentRepository.php
@@ -65,6 +65,7 @@ class ContentRepository extends Repository
         }
         if (ExtensionManagementUtility::isLoaded('flux')) {
             $constraints[] = $query->equals('tx_flux_parent', 0);
+            $constraints[] = $query->lessThan('colpos', 1000);
         }
 
         $query->matching(


### PR DESCRIPTION
with FLUX 9.7.2 the use of the constraint for tx_flux_parent cannot be used anymore to exclude flux-children from being rendered twice. this PR adds another constraint for the virtual colPos-numbers calculated by Flux. see also https://github.com/FluidTYPO3/flux/releases/tag/9.7.2